### PR TITLE
feat: DBテストサンプルケース拡充 (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ winforms_test/
 │           ├── CrudForm.cs         # DataGridView による CRUD 画面
 │           ├── MessageForm.cs      # MessageBox・ダイアログの条件分岐
 │           ├── FunctionKeyForm.cs  # F1/F5/F10/Esc キーバインド
-│           └── InputControlForm.cs # 入力制御（半角英数、IME、数値のみ等）
+│           ├── InputControlForm.cs # 入力制御（半角英数、IME、数値のみ等）
+│           └── DbCrudForm.cs      # DB バックエンドの CRUD 画面（LocalDB）
 ├── tests/
 │   └── testapp/                    # TestApp 用 JSON テストスイート
 │       ├── 00_inspect.json         # UI ツリーインスペクション（デバッグ用）
@@ -78,7 +79,7 @@ winforms_test/
 │       ├── 03_message.json         # MessageBox 条件分岐テスト
 │       ├── 04_functionkey.json     # ファンクションキーテスト
 │       ├── 05_input_control.json   # 入力制御テスト
-│       └── 06_db_assertion.json   # DB期待値確認テスト（サンプル）
+│       └── 06_db_assertion.json   # DB CRUD操作＋期待値確認テスト
 └── README.md
 ```
 
@@ -177,6 +178,7 @@ dotnet run --project src/WinFormsE2E -- tests/testapp/01_navigation.json --evide
 | `wait` | `ms` ミリ秒だけ実行を一時停止 |
 | `inspect` | UI Automation ツリーをコンソールにダンプ（デバッグ用。`ms` を最大深度として使用） |
 | `assertDb` | DB クエリを実行し、結果を `expectedRows` と照合（`database` 設定が必要） |
+| `executeDb` | DB に対して任意の SQL（DDL/DML）を実行（`database` 設定が必要） |
 
 ### アサート `expect` オブジェクト
 ```json
@@ -212,6 +214,24 @@ operator: `equals`, `contains`, `startsWith`, `endsWith`, `notEquals`
 - 値の型: 文字列、数値、`null` に対応。型変換を含む柔軟な比較を実施
 - サポートプロバイダー: `sqlserver`（`mssql` も可）
 - エビデンスが有効な場合、クエリ結果は HTML レポートにテーブル表示され、失敗セルがハイライトされます
+
+### DB 実行 `executeDb` ステップ
+
+`executeDb` アクションは任意の SQL（DDL/DML）を実行します。テーブルの作成、データの初期化、クリーンアップ等に使用します。
+
+```json
+{
+  "action": "executeDb",
+  "description": "テーブルを初期化",
+  "query": {
+    "connectionName": "main",
+    "sql": "DELETE FROM Items"
+  }
+}
+```
+
+- `query.connectionName`: `database.connections` で定義した接続名
+- `query.sql`: 実行する SQL 文（CREATE TABLE, INSERT, UPDATE, DELETE, DROP TABLE 等）
 
 ---
 

--- a/src/TestApp/Forms/DbCrudForm.cs
+++ b/src/TestApp/Forms/DbCrudForm.cs
@@ -1,0 +1,157 @@
+using System.ComponentModel;
+using System.Data;
+using Microsoft.Data.SqlClient;
+using TestApp.Models;
+
+namespace TestApp.Forms;
+
+public class DbCrudForm : Form
+{
+    private const string ConnectionString =
+        @"Data Source=(localdb)\MSSQLLocalDB;Database=TestDb;Integrated Security=true;TrustServerCertificate=true;";
+
+    private readonly DataGridView _grid;
+    private readonly TextBox _txtName;
+    private readonly TextBox _txtDescription;
+    private readonly Button _btnAdd;
+    private readonly Button _btnUpdate;
+    private readonly Button _btnDelete;
+    private readonly Button _btnBack;
+    private readonly BindingList<Item> _items = new();
+
+    public DbCrudForm()
+    {
+        Text = "データCRUD (DB)";
+        Name = "DbCrudForm";
+        Size = new Size(800, 600);
+        StartPosition = FormStartPosition.CenterScreen;
+
+        // DataGridView
+        _grid = new DataGridView
+        {
+            Name = "DbCrudDataGrid",
+            Location = new Point(20, 20),
+            Size = new Size(740, 300),
+            AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.Fill,
+            SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+            MultiSelect = false,
+            AllowUserToAddRows = false,
+            AllowUserToDeleteRows = false,
+            ReadOnly = true,
+            DataSource = _items
+        };
+        _grid.SelectionChanged += Grid_SelectionChanged;
+
+        // Input form
+        var lblName = new Label { Text = "名前:", Location = new Point(20, 340), AutoSize = true };
+        _txtName = new TextBox { Name = "TxtDbItemName", Location = new Point(80, 337), Size = new Size(200, 25) };
+
+        var lblDesc = new Label { Text = "説明:", Location = new Point(20, 375), AutoSize = true };
+        _txtDescription = new TextBox { Name = "TxtDbItemDescription", Location = new Point(80, 372), Size = new Size(400, 25) };
+
+        // Buttons
+        _btnAdd = new Button { Name = "BtnDbAdd", Text = "追加(&A)", Location = new Point(20, 420), Size = new Size(100, 30) };
+        _btnAdd.Click += BtnAdd_Click;
+
+        _btnUpdate = new Button { Name = "BtnDbUpdate", Text = "更新(&U)", Location = new Point(130, 420), Size = new Size(100, 30), Enabled = false };
+        _btnUpdate.Click += BtnUpdate_Click;
+
+        _btnDelete = new Button { Name = "BtnDbDelete", Text = "削除(&D)", Location = new Point(240, 420), Size = new Size(100, 30), Enabled = false };
+        _btnDelete.Click += BtnDelete_Click;
+
+        _btnBack = new Button { Name = "BtnDbCrudBack", Text = "メインへ戻る(&B)", Location = new Point(20, 520), Size = new Size(120, 30) };
+        _btnBack.Click += (s, e) => Close();
+
+        Controls.AddRange([_grid, lblName, _txtName, lblDesc, _txtDescription, _btnAdd, _btnUpdate, _btnDelete, _btnBack]);
+
+        Load += (s, e) => LoadData();
+    }
+
+    private void LoadData()
+    {
+        _items.Clear();
+        using var conn = new SqlConnection(ConnectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT Id, Name, Description, CreatedAt FROM Items ORDER BY Id";
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            _items.Add(new Item
+            {
+                Id = reader.GetInt32(0),
+                Name = reader.GetString(1),
+                Description = reader.IsDBNull(2) ? string.Empty : reader.GetString(2),
+                CreatedAt = reader.GetDateTime(3)
+            });
+        }
+        ClearInputs();
+    }
+
+    private void Grid_SelectionChanged(object? sender, EventArgs e)
+    {
+        var hasSelection = _grid.SelectedRows.Count > 0;
+        _btnUpdate.Enabled = hasSelection;
+        _btnDelete.Enabled = hasSelection;
+
+        if (hasSelection && _grid.SelectedRows[0].DataBoundItem is Item item)
+        {
+            _txtName.Text = item.Name;
+            _txtDescription.Text = item.Description;
+        }
+    }
+
+    private void BtnAdd_Click(object? sender, EventArgs e)
+    {
+        if (string.IsNullOrWhiteSpace(_txtName.Text)) return;
+
+        using var conn = new SqlConnection(ConnectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "INSERT INTO Items (Name, Description, CreatedAt) VALUES (@Name, @Description, @CreatedAt)";
+        cmd.Parameters.AddWithValue("@Name", _txtName.Text.Trim());
+        cmd.Parameters.AddWithValue("@Description", _txtDescription.Text.Trim());
+        cmd.Parameters.AddWithValue("@CreatedAt", DateTime.Now);
+        cmd.ExecuteNonQuery();
+
+        LoadData();
+    }
+
+    private void BtnUpdate_Click(object? sender, EventArgs e)
+    {
+        if (_grid.SelectedRows.Count == 0 || string.IsNullOrWhiteSpace(_txtName.Text)) return;
+        if (_grid.SelectedRows[0].DataBoundItem is not Item item) return;
+
+        using var conn = new SqlConnection(ConnectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "UPDATE Items SET Name = @Name, Description = @Description WHERE Id = @Id";
+        cmd.Parameters.AddWithValue("@Name", _txtName.Text.Trim());
+        cmd.Parameters.AddWithValue("@Description", _txtDescription.Text.Trim());
+        cmd.Parameters.AddWithValue("@Id", item.Id);
+        cmd.ExecuteNonQuery();
+
+        LoadData();
+    }
+
+    private void BtnDelete_Click(object? sender, EventArgs e)
+    {
+        if (_grid.SelectedRows.Count == 0) return;
+        if (_grid.SelectedRows[0].DataBoundItem is not Item item) return;
+
+        using var conn = new SqlConnection(ConnectionString);
+        conn.Open();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM Items WHERE Id = @Id";
+        cmd.Parameters.AddWithValue("@Id", item.Id);
+        cmd.ExecuteNonQuery();
+
+        LoadData();
+    }
+
+    private void ClearInputs()
+    {
+        _txtName.Text = string.Empty;
+        _txtDescription.Text = string.Empty;
+    }
+}

--- a/src/TestApp/Forms/MainForm.cs
+++ b/src/TestApp/Forms/MainForm.cs
@@ -19,6 +19,7 @@ public class MainForm : Form
         menuScreens.DropDownItems.Add(new ToolStripMenuItem("メッセージ(&M)", null, (s, e) => OpenForm<MessageForm>()) { Name = "MenuMessage" });
         menuScreens.DropDownItems.Add(new ToolStripMenuItem("ファンクションキー(&F)", null, (s, e) => OpenForm<FunctionKeyForm>()) { Name = "MenuFunctionKey" });
         menuScreens.DropDownItems.Add(new ToolStripMenuItem("入力制御(&I)", null, (s, e) => OpenForm<InputControlForm>()) { Name = "MenuInputControl" });
+        menuScreens.DropDownItems.Add(new ToolStripMenuItem("データCRUD DB(&B)", null, (s, e) => OpenForm<DbCrudForm>()) { Name = "MenuDbCrud" });
         _menuStrip.Items.Add(menuScreens);
 
         _statusStrip = new StatusStrip { Name = "MainStatusStrip" };

--- a/src/TestApp/TestApp.csproj
+++ b/src/TestApp/TestApp.csproj
@@ -6,4 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/WinFormsE2E/Core/StepExecutor.cs
+++ b/src/WinFormsE2E/Core/StepExecutor.cs
@@ -40,6 +40,7 @@ public class StepExecutor
                 "wait" => ExecuteWait(step),
                 "inspect" => ExecuteInspect(step, context),
                 "assertdb" => ExecuteAssertDb(step, context, collector),
+                "executedb" => ExecuteExecuteDb(step, context),
                 _ => throw new InvalidOperationException($"Unknown action: {step.Action}")
             };
 
@@ -276,6 +277,17 @@ public class StepExecutor
             }
         }
         catch (ElementNotAvailableException) { }
+    }
+
+    private StepResult ExecuteExecuteDb(TestStep step, TestContext context)
+    {
+        if (context.DbManager == null)
+            throw new InvalidOperationException("'executeDb' requires 'database' configuration in the test suite.");
+        if (step.Query == null)
+            throw new InvalidOperationException("'executeDb' action requires 'query' field.");
+
+        var affected = context.DbManager.ExecuteNonQuery(step.Query.ConnectionName, step.Query.Sql);
+        return StepResult.Pass(step.DisplayName, 0);
     }
 
     private StepResult ExecuteAssertDb(TestStep step, TestContext context, IEvidenceCollector? collector)

--- a/src/WinFormsE2E/Database/DbConnectionManager.cs
+++ b/src/WinFormsE2E/Database/DbConnectionManager.cs
@@ -15,6 +15,14 @@ public class DbConnectionManager : IDisposable
         _connectionInfos = config.Connections;
     }
 
+    public int ExecuteNonQuery(string connectionName, string sql)
+    {
+        var connection = GetOrCreateConnection(connectionName);
+        using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        return command.ExecuteNonQuery();
+    }
+
     public DbQueryResult ExecuteQuery(string connectionName, string sql)
     {
         var connection = GetOrCreateConnection(connectionName);

--- a/tests/testapp/06_db_assertion.json
+++ b/tests/testapp/06_db_assertion.json
@@ -1,5 +1,5 @@
 {
-  "suite": "DB期待値確認テスト（サンプル）",
+  "suite": "DB期待値確認テスト",
   "application": {
     "path": "src\\TestApp\\bin\\Debug\\net9.0-windows\\TestApp.exe",
     "startArgs": "",
@@ -10,7 +10,7 @@
     "connections": {
       "main": {
         "provider": "sqlserver",
-        "connectionString": "Server=localhost;Database=TestDb;Trusted_Connection=true;TrustServerCertificate=true;"
+        "connectionString": "Data Source=(localdb)\\MSSQLLocalDB;Database=TestDb;Integrated Security=true;TrustServerCertificate=true;"
       }
     }
   },
@@ -20,7 +20,45 @@
   },
   "scenarios": [
     {
-      "name": "CRUD操作後のDB確認",
+      "name": "DB初期化",
+      "steps": [
+        {
+          "action": "executeDb",
+          "description": "Itemsテーブルを作成（存在しない場合）",
+          "query": {
+            "connectionName": "main",
+            "sql": "IF OBJECT_ID('Items', 'U') IS NULL CREATE TABLE Items (Id int IDENTITY(1,1) PRIMARY KEY, Name nvarchar(200) NOT NULL, Description nvarchar(500), CreatedAt datetime2 NOT NULL DEFAULT GETDATE())"
+          }
+        },
+        {
+          "action": "executeDb",
+          "description": "テーブルデータを全削除",
+          "query": {
+            "connectionName": "main",
+            "sql": "DELETE FROM Items"
+          }
+        },
+        {
+          "action": "executeDb",
+          "description": "IDENTITYをリセット",
+          "query": {
+            "connectionName": "main",
+            "sql": "DBCC CHECKIDENT ('Items', RESEED, 0)"
+          }
+        },
+        {
+          "action": "assertDb",
+          "description": "テーブルが空であることを確認",
+          "query": {
+            "connectionName": "main",
+            "sql": "SELECT Id, Name, Description FROM Items"
+          },
+          "expectedRows": []
+        }
+      ]
+    },
+    {
+      "name": "UI操作によるDB登録確認",
       "steps": [
         {
           "action": "click",
@@ -29,26 +67,229 @@
         },
         {
           "action": "click",
-          "target": { "name": "データCRUD(C)" },
-          "description": "データCRUDメニューをクリック"
+          "target": { "name": "データCRUD DB(B)" },
+          "description": "データCRUD DBメニューをクリック"
         },
         {
           "action": "waitForWindow",
-          "windowTitle": "データCRUD",
-          "description": "CRUD画面が表示されるまで待機"
+          "windowTitle": "データCRUD (DB)",
+          "description": "DB CRUD画面が表示されるまで待機"
+        },
+        {
+          "action": "type",
+          "target": { "automationId": "TxtDbItemName" },
+          "text": "テストアイテム1",
+          "description": "名前を入力"
+        },
+        {
+          "action": "type",
+          "target": { "automationId": "TxtDbItemDescription" },
+          "text": "テスト説明1",
+          "description": "説明を入力"
+        },
+        {
+          "action": "click",
+          "target": { "automationId": "BtnDbAdd" },
+          "description": "追加ボタンをクリック"
+        },
+        {
+          "action": "wait",
+          "ms": 500,
+          "description": "DB反映を待機"
         },
         {
           "action": "assertDb",
-          "description": "初期データが存在することを確認",
+          "description": "1件目のデータがDBに登録されていることを確認",
           "query": {
             "connectionName": "main",
-            "sql": "SELECT TOP 5 Id, Name FROM SampleTable ORDER BY Id"
+            "sql": "SELECT Id, Name, Description FROM Items ORDER BY Id"
           },
           "expectedRows": [
-            [1, "サンプルデータ1"],
-            [2, "サンプルデータ2"],
-            [3, "サンプルデータ3"]
+            [1, "テストアイテム1", "テスト説明1"]
           ]
+        }
+      ]
+    },
+    {
+      "name": "複数データ登録と画面表示の一致確認",
+      "steps": [
+        {
+          "action": "click",
+          "target": { "name": "画面(S)" },
+          "description": "画面メニューをクリック"
+        },
+        {
+          "action": "click",
+          "target": { "name": "データCRUD DB(B)" },
+          "description": "データCRUD DBメニューをクリック"
+        },
+        {
+          "action": "waitForWindow",
+          "windowTitle": "データCRUD (DB)",
+          "description": "DB CRUD画面が表示されるまで待機"
+        },
+        {
+          "action": "type",
+          "target": { "automationId": "TxtDbItemName" },
+          "text": "テストアイテム2",
+          "description": "2件目の名前を入力"
+        },
+        {
+          "action": "type",
+          "target": { "automationId": "TxtDbItemDescription" },
+          "text": "テスト説明2",
+          "description": "2件目の説明を入力"
+        },
+        {
+          "action": "click",
+          "target": { "automationId": "BtnDbAdd" },
+          "description": "追加ボタンをクリック"
+        },
+        {
+          "action": "wait",
+          "ms": 500,
+          "description": "DB反映を待機"
+        },
+        {
+          "action": "assertDb",
+          "description": "2件のデータがDBに登録されていることを確認",
+          "query": {
+            "connectionName": "main",
+            "sql": "SELECT Id, Name, Description FROM Items ORDER BY Id"
+          },
+          "expectedRows": [
+            [1, "テストアイテム1", "テスト説明1"],
+            [2, "テストアイテム2", "テスト説明2"]
+          ]
+        },
+        {
+          "action": "assert",
+          "target": { "automationId": "DbCrudDataGrid" },
+          "expect": { "property": "Name", "operator": "contains", "value": "テストアイテム1" },
+          "description": "画面のDataGridViewにDB登録済みデータ（1件目）が表示されていることを確認"
+        },
+        {
+          "action": "assert",
+          "target": { "automationId": "DbCrudDataGrid" },
+          "expect": { "property": "Name", "operator": "contains", "value": "テストアイテム2" },
+          "description": "画面のDataGridViewにDB登録済みデータ（2件目）が表示されていることを確認"
+        }
+      ]
+    },
+    {
+      "name": "UI操作によるDB更新確認",
+      "steps": [
+        {
+          "action": "click",
+          "target": { "name": "画面(S)" },
+          "description": "画面メニューをクリック"
+        },
+        {
+          "action": "click",
+          "target": { "name": "データCRUD DB(B)" },
+          "description": "データCRUD DBメニューをクリック"
+        },
+        {
+          "action": "waitForWindow",
+          "windowTitle": "データCRUD (DB)",
+          "description": "DB CRUD画面が表示されるまで待機"
+        },
+        {
+          "action": "click",
+          "target": { "name": "テストアイテム1" },
+          "description": "1件目の行を選択"
+        },
+        {
+          "action": "clear",
+          "target": { "automationId": "TxtDbItemName" },
+          "description": "名前フィールドをクリア"
+        },
+        {
+          "action": "type",
+          "target": { "automationId": "TxtDbItemName" },
+          "text": "更新済みアイテム1",
+          "description": "新しい名前を入力"
+        },
+        {
+          "action": "click",
+          "target": { "automationId": "BtnDbUpdate" },
+          "description": "更新ボタンをクリック"
+        },
+        {
+          "action": "wait",
+          "ms": 500,
+          "description": "DB反映を待機"
+        },
+        {
+          "action": "assertDb",
+          "description": "1件目のデータがDBで更新されていることを確認",
+          "query": {
+            "connectionName": "main",
+            "sql": "SELECT Id, Name, Description FROM Items ORDER BY Id"
+          },
+          "expectedRows": [
+            [1, "更新済みアイテム1", "テスト説明1"],
+            [2, "テストアイテム2", "テスト説明2"]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "UI操作によるDB削除確認",
+      "steps": [
+        {
+          "action": "click",
+          "target": { "name": "画面(S)" },
+          "description": "画面メニューをクリック"
+        },
+        {
+          "action": "click",
+          "target": { "name": "データCRUD DB(B)" },
+          "description": "データCRUD DBメニューをクリック"
+        },
+        {
+          "action": "waitForWindow",
+          "windowTitle": "データCRUD (DB)",
+          "description": "DB CRUD画面が表示されるまで待機"
+        },
+        {
+          "action": "click",
+          "target": { "name": "更新済みアイテム1" },
+          "description": "1件目の行を選択"
+        },
+        {
+          "action": "click",
+          "target": { "automationId": "BtnDbDelete" },
+          "description": "削除ボタンをクリック"
+        },
+        {
+          "action": "wait",
+          "ms": 500,
+          "description": "DB反映を待機"
+        },
+        {
+          "action": "assertDb",
+          "description": "1件目がDBから削除されていることを確認",
+          "query": {
+            "connectionName": "main",
+            "sql": "SELECT Id, Name, Description FROM Items ORDER BY Id"
+          },
+          "expectedRows": [
+            [2, "テストアイテム2", "テスト説明2"]
+          ]
+        }
+      ]
+    },
+    {
+      "name": "クリーンアップ",
+      "steps": [
+        {
+          "action": "executeDb",
+          "description": "テストテーブルを削除",
+          "query": {
+            "connectionName": "main",
+            "sql": "DROP TABLE IF EXISTS Items"
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary
- **DbCrudForm 新規作成**: SQL Server (LocalDB) バックエンドの CRUD フォームを追加。既存の CrudForm（インメモリ）はそのまま維持
- **executeDb アクション追加**: テスト JSON 内でテーブル作成・初期化・クリーンアップが可能に（DbConnectionManager に ExecuteNonQuery メソッド追加）
- **06_db_assertion.json を6シナリオに拡充**: DB初期化 → UI登録確認 → 複数登録+画面一致確認 → UI更新確認 → UI削除確認 → クリーンアップ

Closes #26

## Test plan
- [ ] `dotnet build` でビルド成功確認
- [ ] TestApp 起動 → メニュー「画面」→「データCRUD DB」が開けること確認
- [ ] LocalDB に TestDb を作成後、`dotnet run --project src/WinFormsE2E -- tests/testapp/06_db_assertion.json --evidence` で全シナリオ PASS 確認
- [ ] 既存テスト `02_crud.json` が影響を受けないこと確認
- [ ] HTML エビデンスレポートに DB クエリ結果が表示されること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)