### PR TITLE
feat: ファイル出力ダイアログ対応 (assertFile/deleteFile)

### DIFF
--- a/src/TestApp/Forms/FileOutputForm.cs
+++ b/src/TestApp/Forms/FileOutputForm.cs
@@ -64,7 +64,8 @@ public class FileOutputForm : Form
         {
             Filter = "テキストファイル (*.txt)|*.txt|すべてのファイル (*.*)|*.*",
             DefaultExt = "txt",
-            Title = "名前を付けて保存"
+            Title = "名前を付けて保存",
+            InitialDirectory = Path.GetTempPath()
         };
 
         if (dialog.ShowDialog(this) == DialogResult.OK)

--- a/src/TestApp/Forms/FileOutputForm.cs
+++ b/src/TestApp/Forms/FileOutputForm.cs
@@ -1,0 +1,80 @@
+namespace TestApp.Forms;
+
+public class FileOutputForm : Form
+{
+    private readonly TextBox _txtContent;
+    private readonly Label _lblResult;
+
+    public FileOutputForm()
+    {
+        Text = "ファイル出力";
+        Name = "FileOutputForm";
+        Size = new Size(800, 600);
+        StartPosition = FormStartPosition.CenterScreen;
+
+        var lblTitle = new Label
+        {
+            Text = "ファイル出力テスト",
+            Font = new Font(Font.FontFamily, 14, FontStyle.Bold),
+            AutoSize = true,
+            Location = new Point(20, 20)
+        };
+
+        var lblContent = new Label { Text = "出力内容:", Location = new Point(20, 70), AutoSize = true };
+        _txtContent = new TextBox
+        {
+            Name = "TxtFileContent",
+            Location = new Point(100, 67),
+            Size = new Size(400, 25)
+        };
+
+        var btnSave = new Button
+        {
+            Name = "BtnSaveFile",
+            Text = "ファイル保存(&S)",
+            Location = new Point(20, 110),
+            Size = new Size(140, 35)
+        };
+        btnSave.Click += BtnSave_Click;
+
+        _lblResult = new Label
+        {
+            Name = "LblFileResult",
+            Text = "結果: (未操作)",
+            Location = new Point(20, 170),
+            AutoSize = true,
+            Font = new Font(Font.FontFamily, 11)
+        };
+
+        var btnBack = new Button
+        {
+            Name = "BtnFileBack",
+            Text = "メインへ戻る(&B)",
+            Location = new Point(20, 520),
+            Size = new Size(120, 30)
+        };
+        btnBack.Click += (s, e) => Close();
+
+        Controls.AddRange([lblTitle, lblContent, _txtContent, btnSave, _lblResult, btnBack]);
+    }
+
+    private void BtnSave_Click(object? sender, EventArgs e)
+    {
+        using var dialog = new SaveFileDialog
+        {
+            Filter = "テキストファイル (*.txt)|*.txt|すべてのファイル (*.*)|*.*",
+            DefaultExt = "txt",
+            Title = "名前を付けて保存"
+        };
+
+        if (dialog.ShowDialog(this) == DialogResult.OK)
+        {
+            File.WriteAllText(dialog.FileName, _txtContent.Text);
+            _lblResult.Text = $"結果: ファイルを保存しました ({dialog.FileName})";
+        }
+        else
+        {
+            _lblResult.Text = "結果: 保存がキャンセルされました";
+        }
+    }
+}

--- a/src/TestApp/Forms/MainForm.cs
+++ b/src/TestApp/Forms/MainForm.cs
@@ -21,6 +21,7 @@ public class MainForm : Form
         menuScreens.DropDownItems.Add(new ToolStripMenuItem("入力制御(&I)", null, (s, e) => OpenForm<InputControlForm>()) { Name = "MenuInputControl" });
         menuScreens.DropDownItems.Add(new ToolStripMenuItem("データCRUD DB(&B)", null, (s, e) => OpenForm<DbCrudForm>()) { Name = "MenuDbCrud" });
         menuScreens.DropDownItems.Add(new ToolStripMenuItem("コンボボックス(&O)", null, (s, e) => OpenForm<ComboBoxForm>()) { Name = "MenuComboBox" });
+        menuScreens.DropDownItems.Add(new ToolStripMenuItem("ファイル出力(&E)", null, (s, e) => OpenForm<FileOutputForm>()) { Name = "MenuFileOutput" });
         _menuStrip.Items.Add(menuScreens);
 
         var menuHelp = new ToolStripMenuItem("ヘルプ(&H)") { Name = "MenuHelp" };

--- a/src/WinFormsE2E/Core/StepExecutor.cs
+++ b/src/WinFormsE2E/Core/StepExecutor.cs
@@ -42,6 +42,8 @@ public class StepExecutor
                 "assertdb" => ExecuteAssertDb(step, context, collector),
                 "executedb" => ExecuteExecuteDb(step, context),
                 "expandcollapse" => ExecuteExpandCollapse(step, context),
+                "assertfile" => ExecuteAssertFile(step),
+                "deletefile" => ExecuteDeleteFile(step),
                 _ => throw new InvalidOperationException($"Unknown action: {step.Action}")
             };
 
@@ -425,6 +427,45 @@ public class StepExecutor
         if (value == null || value == DBNull.Value) return "null";
         if (value is string s) return $"\"{s}\"";
         return value.ToString() ?? "null";
+    }
+
+    private static StepResult ExecuteAssertFile(TestStep step)
+    {
+        if (step.Value == null) throw new InvalidOperationException("'assertFile' action requires 'value' field (file path).");
+        if (step.Expect == null) throw new InvalidOperationException("'assertFile' action requires 'expect' field.");
+
+        var filePath = Environment.ExpandEnvironmentVariables(step.Value);
+
+        var actual = step.Expect.Property.ToLowerInvariant() switch
+        {
+            "exists" => System.IO.File.Exists(filePath).ToString(),
+            _ => throw new InvalidOperationException($"Unsupported assertFile property: {step.Expect.Property}")
+        };
+
+        var passed = step.Expect.Operator.ToLowerInvariant() switch
+        {
+            "equals" or "equalsignorecase" => string.Equals(actual, step.Expect.Value, StringComparison.OrdinalIgnoreCase),
+            "notequals" => !string.Equals(actual, step.Expect.Value, StringComparison.OrdinalIgnoreCase),
+            _ => string.Equals(actual, step.Expect.Value, StringComparison.OrdinalIgnoreCase)
+        };
+
+        return passed
+            ? StepResult.Pass(step.DisplayName, 0)
+            : StepResult.Fail(step.DisplayName, $"Expected file [{step.Expect.Property}] {step.Expect.Operator} \"{step.Expect.Value}\", but was \"{actual}\" (path: {filePath})", 0);
+    }
+
+    private static StepResult ExecuteDeleteFile(TestStep step)
+    {
+        if (step.Value == null) throw new InvalidOperationException("'deleteFile' action requires 'value' field (file path).");
+
+        var filePath = Environment.ExpandEnvironmentVariables(step.Value);
+
+        if (System.IO.File.Exists(filePath))
+        {
+            System.IO.File.Delete(filePath);
+        }
+
+        return StepResult.Pass(step.DisplayName, 0);
     }
 
     private AutomationElement FindElement(TestStep step, TestContext context)

--- a/src/WinFormsE2E/Core/StepExecutor.cs
+++ b/src/WinFormsE2E/Core/StepExecutor.cs
@@ -42,8 +42,8 @@ public class StepExecutor
                 "assertdb" => ExecuteAssertDb(step, context, collector),
                 "executedb" => ExecuteExecuteDb(step, context),
                 "expandcollapse" => ExecuteExpandCollapse(step, context),
-                "assertfile" => ExecuteAssertFile(step),
-                "deletefile" => ExecuteDeleteFile(step),
+                "assertfile" => ExecuteAssertFile(step, collector),
+                "deletefile" => ExecuteDeleteFile(step, collector),
                 _ => throw new InvalidOperationException($"Unknown action: {step.Action}")
             };
 
@@ -429,16 +429,18 @@ public class StepExecutor
         return value.ToString() ?? "null";
     }
 
-    private static StepResult ExecuteAssertFile(TestStep step)
+    private StepResult ExecuteAssertFile(TestStep step, IEvidenceCollector? collector)
     {
         if (step.Value == null) throw new InvalidOperationException("'assertFile' action requires 'value' field (file path).");
         if (step.Expect == null) throw new InvalidOperationException("'assertFile' action requires 'expect' field.");
 
         var filePath = Environment.ExpandEnvironmentVariables(step.Value);
+        var fileExists = System.IO.File.Exists(filePath);
+        long? fileSize = fileExists ? new System.IO.FileInfo(filePath).Length : null;
 
         var actual = step.Expect.Property.ToLowerInvariant() switch
         {
-            "exists" => System.IO.File.Exists(filePath).ToString(),
+            "exists" => fileExists.ToString(),
             _ => throw new InvalidOperationException($"Unsupported assertFile property: {step.Expect.Property}")
         };
 
@@ -449,21 +451,55 @@ public class StepExecutor
             _ => string.Equals(actual, step.Expect.Value, StringComparison.OrdinalIgnoreCase)
         };
 
+        SafeCall(() =>
+        {
+            if (collector is ScreenshotCollector sc)
+            {
+                var attachment = new FileOperationAttachment(
+                    step.Description ?? "File Assert",
+                    "assertFile",
+                    filePath,
+                    fileExisted: fileExists,
+                    fileExists: fileExists,
+                    fileSize: fileSize,
+                    passed: passed,
+                    expectedValue: $"{step.Expect.Property} {step.Expect.Operator} {step.Expect.Value}",
+                    actualValue: actual);
+                sc.AttachToCurrentStep(attachment);
+            }
+        });
+
         return passed
             ? StepResult.Pass(step.DisplayName, 0)
             : StepResult.Fail(step.DisplayName, $"Expected file [{step.Expect.Property}] {step.Expect.Operator} \"{step.Expect.Value}\", but was \"{actual}\" (path: {filePath})", 0);
     }
 
-    private static StepResult ExecuteDeleteFile(TestStep step)
+    private StepResult ExecuteDeleteFile(TestStep step, IEvidenceCollector? collector)
     {
         if (step.Value == null) throw new InvalidOperationException("'deleteFile' action requires 'value' field (file path).");
 
         var filePath = Environment.ExpandEnvironmentVariables(step.Value);
+        var fileExisted = System.IO.File.Exists(filePath);
 
-        if (System.IO.File.Exists(filePath))
+        if (fileExisted)
         {
             System.IO.File.Delete(filePath);
         }
+
+        SafeCall(() =>
+        {
+            if (collector is ScreenshotCollector sc)
+            {
+                var attachment = new FileOperationAttachment(
+                    step.Description ?? "File Delete",
+                    "deleteFile",
+                    filePath,
+                    fileExisted: fileExisted,
+                    fileExists: false,
+                    passed: true);
+                sc.AttachToCurrentStep(attachment);
+            }
+        });
 
         return StepResult.Pass(step.DisplayName, 0);
     }

--- a/src/WinFormsE2E/Evidence/FileOperationAttachment.cs
+++ b/src/WinFormsE2E/Evidence/FileOperationAttachment.cs
@@ -1,0 +1,52 @@
+namespace WinFormsE2E.Evidence;
+
+public class FileOperationAttachment : IEvidenceAttachment
+{
+    public string Name { get; }
+    public string Type => "file-operation";
+    public string? FilePath => null;
+    public string? Content { get; }
+
+    public string Operation { get; }
+    public string TargetPath { get; }
+    public bool FileExisted { get; }
+    public bool FileExists { get; }
+    public long? FileSize { get; }
+    public bool Passed { get; }
+    public string? ExpectedValue { get; }
+    public string? ActualValue { get; }
+
+    public FileOperationAttachment(
+        string label,
+        string operation,
+        string targetPath,
+        bool fileExisted,
+        bool fileExists,
+        long? fileSize = null,
+        bool passed = true,
+        string? expectedValue = null,
+        string? actualValue = null)
+    {
+        Name = label;
+        Operation = operation;
+        TargetPath = targetPath;
+        FileExisted = fileExisted;
+        FileExists = fileExists;
+        FileSize = fileSize;
+        Passed = passed;
+        ExpectedValue = expectedValue;
+        ActualValue = actualValue;
+        Content = BuildContentSummary(operation, targetPath, fileExists);
+    }
+
+    private static string BuildContentSummary(string operation, string path, bool exists)
+    {
+        var fileName = System.IO.Path.GetFileName(path);
+        return operation switch
+        {
+            "assertFile" => $"{fileName}: exists={exists}",
+            "deleteFile" => $"{fileName}: deleted",
+            _ => $"{fileName}: {operation}"
+        };
+    }
+}

--- a/src/WinFormsE2E/Evidence/HtmlReportGenerator.cs
+++ b/src/WinFormsE2E/Evidence/HtmlReportGenerator.cs
@@ -98,13 +98,13 @@ public class HtmlReportGenerator
 
                 sb.AppendLine("</div>"); // screenshots
 
-                // Render DB query attachments
+                // Render attachments
                 foreach (var attachment in stepEvidence.Attachments)
                 {
                     if (attachment is DbQueryAttachment dbAttachment)
-                    {
                         RenderDbQueryTable(sb, dbAttachment);
-                    }
+                    else if (attachment is FileOperationAttachment fileAttachment)
+                        RenderFileOperation(sb, fileAttachment);
                 }
 
                 if (stepResult?.Message != null)
@@ -213,6 +213,36 @@ public class HtmlReportGenerator
         sb.AppendLine("</div>");
     }
 
+    private static void RenderFileOperation(StringBuilder sb, FileOperationAttachment attachment)
+    {
+        var statusClass = attachment.Passed ? "file-pass" : "file-fail";
+        sb.AppendLine("<div class=\"file-evidence\">");
+        sb.AppendLine($"<div class=\"file-header\">ファイル操作: {Escape(attachment.Name)}</div>");
+
+        sb.AppendLine("<table class=\"file-table\">");
+        sb.AppendLine("<tbody>");
+
+        sb.AppendLine($"<tr><th>操作</th><td>{Escape(attachment.Operation)}</td></tr>");
+        sb.AppendLine($"<tr><th>パス</th><td><code>{Escape(attachment.TargetPath)}</code></td></tr>");
+
+        if (attachment.Operation == "assertFile")
+        {
+            sb.AppendLine($"<tr><th>期待値</th><td>{Escape(attachment.ExpectedValue ?? "")}</td></tr>");
+            sb.AppendLine($"<tr><th>実際値</th><td class=\"{statusClass}\">{Escape(attachment.ActualValue ?? "")}</td></tr>");
+            if (attachment.FileSize != null)
+                sb.AppendLine($"<tr><th>ファイルサイズ</th><td>{attachment.FileSize:N0} bytes</td></tr>");
+        }
+        else if (attachment.Operation == "deleteFile")
+        {
+            var existed = attachment.FileExisted ? "存在 → 削除済み" : "存在しない（操作不要）";
+            sb.AppendLine($"<tr><th>結果</th><td>{Escape(existed)}</td></tr>");
+        }
+
+        sb.AppendLine("</tbody>");
+        sb.AppendLine("</table>");
+        sb.AppendLine("</div>");
+    }
+
     private static string FormatJsonElement(JsonElement element)
     {
         return element.ValueKind switch
@@ -278,6 +308,14 @@ public class HtmlReportGenerator
         .db-table tbody tr:nth-child(even) { background: #fafafa; }
         .db-row-fail { background: #ffebee !important; }
         .db-cell-fail { background: #ffcdd2 !important; font-weight: bold; color: #c62828; }
+        .file-evidence { margin-top: 12px; padding: 12px; background: #f8f9fa; border-radius: 6px; border: 1px solid #dee2e6; }
+        .file-header { font-weight: bold; margin-bottom: 6px; color: #2e7d32; }
+        .file-table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
+        .file-table th { background: #e8f5e9; padding: 6px 10px; border: 1px solid #c8e6c9; text-align: left; width: 140px; }
+        .file-table td { padding: 6px 10px; border: 1px solid #e0e0e0; }
+        .file-table code { background: #e8eaf6; padding: 2px 6px; border-radius: 3px; font-size: 0.95em; }
+        .file-pass { color: #2e7d32; font-weight: bold; }
+        .file-fail { color: #c62828; font-weight: bold; background: #ffebee; }
         """;
 
     private static string GetScript() => """

--- a/tests/testapp/09_file_output.json
+++ b/tests/testapp/09_file_output.json
@@ -1,0 +1,150 @@
+{
+  "suite": "TestApp ファイル出力テスト",
+  "application": {
+    "path": "src\\TestApp\\bin\\Debug\\net9.0-windows\\TestApp.exe",
+    "startArgs": "",
+    "windowTitle": "テストアプリケーション",
+    "startupWaitMs": 3000
+  },
+  "settings": {
+    "defaultTimeoutMs": 5000,
+    "retryIntervalMs": 200
+  },
+  "scenarios": [
+    {
+      "name": "ファイル出力 — テキストファイルの保存と存在確認",
+      "steps": [
+        {
+          "action": "deleteFile",
+          "value": "%TEMP%\\e2e_test_output.txt",
+          "description": "テスト前クリーンアップ: 出力先ファイルを削除"
+        },
+        {
+          "action": "assertFile",
+          "value": "%TEMP%\\e2e_test_output.txt",
+          "expect": { "property": "exists", "operator": "equals", "value": "false" },
+          "description": "出力ファイルが存在しないことを確認"
+        },
+        {
+          "action": "click",
+          "target": { "name": "画面(S)" },
+          "description": "画面メニューをクリック"
+        },
+        {
+          "action": "click",
+          "target": { "name": "ファイル出力(E)" },
+          "description": "ファイル出力メニューをクリック"
+        },
+        {
+          "action": "waitForWindow",
+          "windowTitle": "ファイル出力",
+          "description": "ファイル出力画面が表示されるまで待機"
+        },
+        {
+          "action": "type",
+          "target": { "automationId": "TxtFileContent" },
+          "text": "E2Eテスト出力内容",
+          "description": "出力内容を入力"
+        },
+        {
+          "action": "click",
+          "target": { "automationId": "BtnSaveFile" },
+          "description": "ファイル保存ボタンをクリック"
+        },
+        {
+          "action": "waitForWindow",
+          "windowTitle": "名前を付けて保存",
+          "timeoutMs": 5000,
+          "description": "名前を付けて保存ダイアログが表示されるまで待機"
+        },
+        {
+          "action": "sendKeys",
+          "keys": "%TEMP%\\e2e_test_output.txt",
+          "description": "ファイル名テキストボックスにパスを入力"
+        },
+        {
+          "action": "sendKeys",
+          "keys": "{ENTER}",
+          "description": "Enterキーで保存を実行"
+        },
+        {
+          "action": "switchWindow",
+          "windowTitle": "ファイル出力",
+          "description": "ファイル出力画面に戻る"
+        },
+        {
+          "action": "assert",
+          "target": { "automationId": "LblFileResult" },
+          "expect": {
+            "property": "Name",
+            "operator": "contains",
+            "value": "ファイルを保存しました"
+          },
+          "description": "保存成功メッセージが表示されていることを確認"
+        },
+        {
+          "action": "assertFile",
+          "value": "%TEMP%\\e2e_test_output.txt",
+          "expect": { "property": "exists", "operator": "equals", "value": "true" },
+          "description": "出力ファイルが存在することを確認"
+        },
+        {
+          "action": "deleteFile",
+          "value": "%TEMP%\\e2e_test_output.txt",
+          "description": "テスト後クリーンアップ: 出力先ファイルを削除"
+        }
+      ]
+    },
+    {
+      "name": "ファイル出力 — 保存ダイアログのキャンセル",
+      "steps": [
+        {
+          "action": "click",
+          "target": { "name": "画面(S)" },
+          "description": "画面メニューをクリック"
+        },
+        {
+          "action": "click",
+          "target": { "name": "ファイル出力(E)" },
+          "description": "ファイル出力メニューをクリック"
+        },
+        {
+          "action": "waitForWindow",
+          "windowTitle": "ファイル出力",
+          "description": "ファイル出力画面が表示されるまで待機"
+        },
+        {
+          "action": "click",
+          "target": { "automationId": "BtnSaveFile" },
+          "description": "ファイル保存ボタンをクリック"
+        },
+        {
+          "action": "waitForWindow",
+          "windowTitle": "名前を付けて保存",
+          "timeoutMs": 5000,
+          "description": "名前を付けて保存ダイアログが表示されるまで待機"
+        },
+        {
+          "action": "sendKeys",
+          "keys": "{ESC}",
+          "description": "Escキーで保存ダイアログをキャンセル"
+        },
+        {
+          "action": "switchWindow",
+          "windowTitle": "ファイル出力",
+          "description": "ファイル出力画面に戻る"
+        },
+        {
+          "action": "assert",
+          "target": { "automationId": "LblFileResult" },
+          "expect": {
+            "property": "Name",
+            "operator": "contains",
+            "value": "保存がキャンセルされました"
+          },
+          "description": "キャンセルメッセージが表示されていることを確認"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/testapp/09_file_output.json
+++ b/tests/testapp/09_file_output.json
@@ -59,13 +59,18 @@
         },
         {
           "action": "sendKeys",
-          "keys": "%TEMP%\\e2e_test_output.txt",
-          "description": "ファイル名テキストボックスにパスを入力"
+          "keys": "e2e_test_output.txt",
+          "description": "ファイル名テキストボックスにファイル名を入力"
         },
         {
           "action": "sendKeys",
           "keys": "{ENTER}",
           "description": "Enterキーで保存を実行"
+        },
+        {
+          "action": "wait",
+          "ms": 500,
+          "description": "ダイアログが閉じるまで待機"
         },
         {
           "action": "switchWindow",


### PR DESCRIPTION
## Summary
- `assertFile` アクション追加: ファイル存在確認（環境変数 `%TEMP%` 等の展開対応）
- `deleteFile` アクション追加: テストクリーンアップ用ファイル削除
- `FileOutputForm` 新規作成: SaveFileDialog を使うサンプル TestApp 画面
- テストシナリオ2本: ファイル保存+存在確認、保存キャンセル

## Test plan
- [x] `dotnet build` 成功
- [x] `09_file_output.json` — 2/2 シナリオ PASSED
  - ファイル保存+存在確認シナリオ
  - 保存ダイアログキャンセルシナリオ

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)